### PR TITLE
docs: update repo names from AI.ThinkingBox(.Data) to thinkingbox(-data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# AI.ThinkingBox.Data
+# thinkingbox-data
 
-This repo contains datasets to use with AI.Thinkingbox.
+This repo contains datasets to use with thinkingbox.
 
 ## Clone this branch
 
 ```bash
-git clone https://github.com/microsoft/AI.ThinkingBox.Data.git
+git clone https://github.com/microsoft/thinkingbox-data.git
 # OR using GitHub CLI
-gh repo clone microsoft/AI.ThinkingBox.Data
+gh repo clone microsoft/thinkingbox-data
 ```
 
 ## Install servers
 
-Create a virtualenv for ThinkingBox (follow instructions in the AI.ThinkingBox README) and activate it
+Create a virtualenv for ThinkingBox (follow instructions in the thinkingbox README) and activate it
 
-Also install typesense (instructions in `AI.ThinkingBox/docs/tools_with_additional_setup.md`)
+Also install typesense (instructions in `thinkingbox/docs/tools_with_additional_setup.md`)
 
 Install server packages in this repo
 
@@ -32,7 +32,7 @@ uv pip install --config-settings editable-mode=compat -e servers/ms_telus_server
 Start the MCP Session Proxy with environment variable THINKINGBOX_DATA pointing to the root of this repo.
 
 ```bash
-THINKINGBOX_DATA="AI.ThinkingBox.Data" tb mcp-start --servers AI.ThinkingBox.Data/servers/servers.yaml
+THINKINGBOX_DATA="thinkingbox-data" tb mcp-start --servers thinkingbox-data/servers/servers.yaml
 ```
 
 Start typesense
@@ -45,7 +45,7 @@ Run a test
 
 ```bash
 # Run one
-tb infer -c config.yaml --dataset AI.ThinkingBox.Data/dataset --agent think --name sandbox_external_retail_group1.py:test_case_ST002_001 --repeat 1 --batch-size 1 --dump testcontext --output output.yaml
+tb infer -c config.yaml --dataset thinkingbox-data/dataset --agent think --name sandbox_external_retail_group1.py:test_case_ST002_001 --repeat 1 --batch-size 1 --dump testcontext --output output.yaml
 
 # Check output
 tb pp output.yaml
@@ -54,7 +54,7 @@ tb pp output.yaml
 Run all sandbox_external_retail, 10 repetitions
 
 ```bash
-tb infer -c config.yaml --dataset AI.ThinkingBox.Data/dataset --agent think --inputs AI.ThinkingBox.Data/dataset/test_case/sandbox_external_retail --repeat 10 --batch-size 40 --output output_sandbox_external_retail_10reps.jsonl
+tb infer -c config.yaml --dataset thinkingbox-data/dataset --agent think --inputs thinkingbox-data/dataset/test_case/sandbox_external_retail --repeat 10 --batch-size 40 --output output_sandbox_external_retail_10reps.jsonl
 ```
 
 ## Third-party code

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,6 +10,6 @@ For help and questions about using this project, please file a GitHub Issue.
 
 ## Microsoft Support Policy
 
-Support for AI.ThinkingBox.Data is limited to the resources listed above. This project is provided
+Support for thinkingbox-data is limited to the resources listed above. This project is provided
 on a best-effort basis by the maintainers; there is no service-level agreement and no Microsoft
 Customer Service & Support (CSS) coverage.

--- a/releases/dataset_2602_external_retail/README.md
+++ b/releases/dataset_2602_external_retail/README.md
@@ -2,11 +2,11 @@
 
 ## Repository
 
-Use the following tag of `AI.ThinkingBox.Data` to use a stable version of this dataset and tools.
+Use the following tag of `thinkingbox-data` to use a stable version of this dataset and tools.
 
 |  |  |
 | - | - |
-| Tag | [ds-external-retail-2026-02-v1.0](https://github.com/microsoft/AI.ThinkingBox.Data/releases/tag/ds-external-retail-2026-02-v1.0) |
+| Tag | [ds-external-retail-2026-02-v1.0](https://github.com/microsoft/thinkingbox-data/releases/tag/ds-external-retail-2026-02-v1.0) |
 
 
 ## Overview
@@ -147,7 +147,7 @@ MCS tests were run with the following parameters:
 
 ## Running
 
-Check `AI.ThinkingBox/README.md` for installing ThinkingBox
+Check `thinkingbox/README.md` for installing ThinkingBox
 
 ```bash
 # Install the servers in the ThinkingBox virtual environment
@@ -157,15 +157,15 @@ uv pip install --config-settings editable-mode=compat -e servers/ms_toloka_serve
 mkdir -p /tmp/typesense/data && typesense-server --data-dir="/tmp/typesense/data" --api-key="Fake" --enable-cors
 
 # Start session proxy
-THINKINGBOX_DATA=AI.ThinkingBox.Data tb mcp-start --servers servers.yaml
+THINKINGBOX_DATA=thinkingbox-data tb mcp-start --servers servers.yaml
 
 # Decode (full100, 20 repetitions)
-tb infer -c config.yaml -d AI.ThinkingBox.Data/dataset -a think \
-    --inputs AI.ThinkingBox.Data/dataset/test_case/sandbox_external_retail/ \
+tb infer -c config.yaml -d thinkingbox-data/dataset -a think \
+    --inputs thinkingbox-data/dataset/test_case/sandbox_external_retail/ \
     --repeat 20 --batch-size 40 -o output_zendesk_external_retail_full100.jsonl
 
 # Decode (quick20, 5 repetitions)
-tb infer -c config.yaml -d AI.ThinkingBox.Data/dataset -a think \
-    --test-list AI.ThinkingBox.Data/releases/dataset_2602_external_retail/testlist_2602_external_retail_quick20.yaml \
+tb infer -c config.yaml -d thinkingbox-data/dataset -a think \
+    --test-list thinkingbox-data/releases/dataset_2602_external_retail/testlist_2602_external_retail_quick20.yaml \
     --repeat 5 --batch-size 40 -o output_zendesk_external_retail_quick20.jsonl
 ```

--- a/releases/dataset_2603_toloka_rl_zendesk/README.md
+++ b/releases/dataset_2603_toloka_rl_zendesk/README.md
@@ -2,11 +2,11 @@
 
 ## Repository
 
-Use the following tag of `AI.ThinkingBox.Data` to use a stable version of this dataset and tools.
+Use the following tag of `thinkingbox-data` to use a stable version of this dataset and tools.
 
 |  |  |
 | - | - |
-| Tag | [ds-toloka-rl-zendesk-2026-03-v1.0](https://github.com/microsoft/AI.ThinkingBox.Data/releases/tag/ds-toloka-rl-zendesk-2026-03-v1.0) |
+| Tag | [ds-toloka-rl-zendesk-2026-03-v1.0](https://github.com/microsoft/thinkingbox-data/releases/tag/ds-toloka-rl-zendesk-2026-03-v1.0) |
 
 
 ## Overview
@@ -107,7 +107,7 @@ Results on `t11_24_25_varset_3_rm` refer to a run on the PPE CAPI deployment of 
 
 ## Running
 
-Check `AI.ThinkingBox/README.md` for installing ThinkingBox
+Check `thinkingbox/README.md` for installing ThinkingBox
 
 ```bash
 # Install the Toloka RL servers in the ThinkingBox virtual environment
@@ -117,10 +117,10 @@ uv pip install --config-settings editable-mode=compat -e servers/ms_toloka_serve
 mkdir -p /tmp/typesense/data && typesense-server --data-dir="/tmp/typesense/data" --api-key="Fake" --enable-cors
 
 # Start session proxy
-THINKINGBOX_DATA=AI.ThinkingBox.Data tb mcp-start --servers AI.ThinkingBox.Data/servers/servers.yaml
+THINKINGBOX_DATA=thinkingbox-data tb mcp-start --servers thinkingbox-data/servers/servers.yaml
 
 # Decode (full dataset, 5 repetitions)
-tb infer -c config.yaml -d AI.ThinkingBox.Data/dataset -a think \
-    --test-list AI.ThinkingBox.Data/releases/dataset_2603_toloka_rl_zendesk/testlist_2603_toloka_rl_zendesk.yaml \
+tb infer -c config.yaml -d thinkingbox-data/dataset -a think \
+    --test-list thinkingbox-data/releases/dataset_2603_toloka_rl_zendesk/testlist_2603_toloka_rl_zendesk.yaml \
     --repeat 5 --batch-size 40 -o output_2603_toloka_rl_zendesk.jsonl
 ```

--- a/releases/dataset_2604_airline_tau_bench/README.md
+++ b/releases/dataset_2604_airline_tau_bench/README.md
@@ -2,11 +2,11 @@
 
 ## Repository
 
-Use the following tag of `AI.ThinkingBox.Data` to use a stable version of this dataset and tools.
+Use the following tag of `thinkingbox-data` to use a stable version of this dataset and tools.
 
 |  |  |
 | - | - |
-| Tag | [ds-airline-tau-bench-2026-04-v1.0](https://github.com/microsoft/AI.ThinkingBox.Data/releases/tag/ds-airline-tau-bench-2026-04-v1.0) |
+| Tag | [ds-airline-tau-bench-2026-04-v1.0](https://github.com/microsoft/thinkingbox-data/releases/tag/ds-airline-tau-bench-2026-04-v1.0) |
 
 
 ## Overview
@@ -77,17 +77,17 @@ Some interaction with the user is expected in most test cases, to retrieve missi
 
 ## Running
 
-Check `AI.ThinkingBox/README.md` for installing ThinkingBox.
+Check `thinkingbox/README.md` for installing ThinkingBox.
 
 ```bash
 # Install the airline tau-bench server in the ThinkingBox virtual environment
 uv pip install --config-settings editable-mode=compat -e servers/thinkingbox_tools
 
 # Start session proxy
-THINKINGBOX_DATA=AI.ThinkingBox.Data tb mcp-start --servers AI.ThinkingBox.Data/servers/servers.yaml
+THINKINGBOX_DATA=thinkingbox-data tb mcp-start --servers thinkingbox-data/servers/servers.yaml
 
 # Decode (full dataset, 5 repetitions)
-tb infer -c config.yaml -d AI.ThinkingBox.Data/dataset -a think \
-    --test-list AI.ThinkingBox.Data/releases/dataset_2604_airline_tau_bench/testlist_2604_airline_tau_bench.yaml \
+tb infer -c config.yaml -d thinkingbox-data/dataset -a think \
+    --test-list thinkingbox-data/releases/dataset_2604_airline_tau_bench/testlist_2604_airline_tau_bench.yaml \
     --repeat 5 --batch-size 40 -o output_2604_airline_tau_bench.jsonl
 ```

--- a/scripts/validate_scenario_tags.py
+++ b/scripts/validate_scenario_tags.py
@@ -15,7 +15,7 @@ appear on the Leaderboard), but any tag that IS present must use a value
 from the enumerated list.
 
 Valid values are derived directly from the Domain and Eval enums in
-AI.ThinkingBox/thinkingbox/common/tag_types.py (installed as a package
+thinkingbox/thinkingbox/common/tag_types.py (installed as a package
 dependency), so this script stays in sync with the source of truth automatically.
 
 See also: validate_tags.py — the complementary tool for full-stack validation

--- a/servers/README.md
+++ b/servers/README.md
@@ -1,13 +1,13 @@
-# AI.ThinkingBox.Data/servers
+# thinkingbox-data/servers
 
-MCP servers to use with AI.Thinkingbox.
+MCP servers to use with thinkingbox.
 
 Each directory is a python package containing one or more MCP servers.
 
 This `servers/` folder is expected to have the following structure (example with one server package, `thinkingbox_tools`):
 
 ```
-AI.ThinkingBox.Data/
+thinkingbox-data/
   servers/
     thinkingbox_tools/  # a group of related servers, in this case the main body of ThinkingBox tests
         tests/  # unit tests for the servers in thinkingbox_tools


### PR DESCRIPTION
## Summary

- Replace stale `AI.ThinkingBox` / `AI.ThinkingBox.Data` references with `thinkingbox` / `thinkingbox-data` to match the public GitHub repo names.
- Updates touch the top-level README, SUPPORT, `servers/README.md`, all three `releases/*/README.md` files, and one docstring path in `scripts/validate_scenario_tags.py`.
- Also fixes two `AI.Thinkingbox` typos (lowercase b) in `README.md:3` and `servers/README.md:3`.

Mirrors the same rename applied to `microsoft/thinkingbox` in commit `2866cfc`.

## Test plan

- [ ] Render the changed README files on GitHub and confirm titles, links, and command snippets read cleanly.
- [ ] Confirm release-tag links resolve (the tag names themselves are unchanged; only the `microsoft/<repo>` segment of the URL was rewritten).
- [ ] `grep -r 'AI\.\?[Tt]hinking[Bb]ox' .` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)