### PR TITLE
Fix Scorecard authentication with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,9 @@ jobs:
       security-events: write
       contents: read
       actions: read
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - uses: actions/checkout@v7
@@ -29,13 +32,6 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: false
-          # Required for private repos. The default GITHUB_TOKEN lacks
-          # GraphQL access to commits/contributors/branch-protection on
-          # private repos. SCORECARD_TOKEN must be a classic PAT with
-          # `repo` + `read:org` scope, 90-day expiration (microsoft-org cap),
-          # SSO-authorized for `microsoft`. Remove this line after the repo
-          # goes public (the default GITHUB_TOKEN works fine on public repos).
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
       - name: Upload SARIF to Security tab
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
# Summary

The Scorecard workflow's personal access token has expired, causing every run since July 6 to fail with `401 Bad credentials`. Switch to GitHub Actions' automatic short-lived token to eliminate manual token rotation.

## Changes

- Grant the private-repository read permissions required by Scorecard.
- Remove the `SCORECARD_TOKEN` input so Scorecard uses the workflow-issued `GITHUB_TOKEN`.
- Preserve `actions: read` for SARIF upload.

## Test plan

The resulting workflow matches the known-good workflow already merged and validated in `microsoft/thinkingbox`:

- Authentication fix: https://github.com/microsoft/thinkingbox/pull/15
- SARIF permission fix: https://github.com/microsoft/thinkingbox/pull/16

The failing run in this repository is https://github.com/microsoft/thinkingbox-data/actions/runs/32084766638/job/95554904114.

## Related issues

N/A