### PR TITLE
Constrain server packages to FastMCP 3.x

### DIFF
--- a/servers/tb_business_ops_servers_202606/pyproject.toml
+++ b/servers/tb_business_ops_servers_202606/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "ThinkingBox business operations MCP servers"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp",
+    "fastmcp>=3.4.3,<4",
     "pydantic",
     "odata-query>=0.9.0",
     "typesense",

--- a/servers/thinkingbox_tools/pyproject.toml
+++ b/servers/thinkingbox_tools/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 description = "Thinkingbox MCP servers"
 requires-python = ">=3.10"
 dependencies = [
-    "fastmcp",
+    "fastmcp>=3.4.3,<4",
     "httpx",
     "pydantic",
     "python-dateutil",


### PR DESCRIPTION
## Summary

- Require FastMCP >=3.4.3,<4 in both server packages.
- Prevent incompatible FastMCP 4.x installations.

## Testing

- 74 thinkingbox_tools tests passed
- 2,423 business-ops unit tests passed
- 2 Typesense-backed MCP integration tests passed